### PR TITLE
Don't post statuses to public TLs if they have a #timelinemute tag

### DIFF
--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -180,6 +180,10 @@ class Status < ApplicationRecord
     @marked_for_mass_destruction
   end
 
+  def has_timelinemute_tag?
+    content.downcase.include? "#timelinemute"
+  end
+
   after_create  :increment_counter_caches
   after_destroy :decrement_counter_caches
 

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -248,8 +248,10 @@ class Status < ApplicationRecord
     end
 
     def as_public_timeline(account = nil, local_only = false)
+      query = timeline_scope(local_only).without_replies
+
       mutetag = Tag.where(name: "timelinemute")
-      query = timeline_scope(local_only).without_replies.not_tagged_with(mutetag)
+      query = query.not_tagged_with(mutetag) if mutetag.count() > 0
 
       apply_timeline_filters(query, account, local_only)
     end

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -180,6 +180,10 @@ class Status < ApplicationRecord
     @marked_for_mass_destruction
   end
 
+  def has_mutetag?
+    tags.where(name: "timelinemute").exists?
+  end
+
   after_create  :increment_counter_caches
   after_destroy :decrement_counter_caches
 

--- a/app/services/fan_out_on_write_service.rb
+++ b/app/services/fan_out_on_write_service.rb
@@ -82,15 +82,15 @@ class FanOutOnWriteService < BaseService
   def deliver_to_public(status)
     Rails.logger.debug "Delivering status #{status.id} to public timeline"
 
-    Redis.current.publish('timeline:public', @payload)
-    Redis.current.publish('timeline:public:local', @payload) if status.local?
+    Redis.current.publish('timeline:public', @payload) if !status.has_timelinemute_tag?
+    Redis.current.publish('timeline:public:local', @payload) if status.local? and !status.has_timelinemute_tag?
   end
 
   def deliver_to_media(status)
     Rails.logger.debug "Delivering status #{status.id} to media timeline"
 
-    Redis.current.publish('timeline:public:media', @payload)
-    Redis.current.publish('timeline:public:local:media', @payload) if status.local?
+    Redis.current.publish('timeline:public:media', @payload) if !status.has_timelinemute_tag?
+    Redis.current.publish('timeline:public:local:media', @payload) if status.local? and !status.has_timelinemute_tag?
   end
 
   def deliver_to_direct_timelines(status)

--- a/app/services/fan_out_on_write_service.rb
+++ b/app/services/fan_out_on_write_service.rb
@@ -24,7 +24,7 @@ class FanOutOnWriteService < BaseService
 
     return if status.reply? && status.in_reply_to_account_id != status.account_id
 
-    deliver_to_public(status)
+    deliver_to_public(status) unless status.has_mutetag?
     deliver_to_media(status) if status.media_attachments.any?
   end
 

--- a/app/services/fan_out_on_write_service.rb
+++ b/app/services/fan_out_on_write_service.rb
@@ -82,15 +82,15 @@ class FanOutOnWriteService < BaseService
   def deliver_to_public(status)
     Rails.logger.debug "Delivering status #{status.id} to public timeline"
 
-    Redis.current.publish('timeline:public', @payload) if !status.has_timelinemute_tag?
-    Redis.current.publish('timeline:public:local', @payload) if status.local? and !status.has_timelinemute_tag?
+    Redis.current.publish('timeline:public', @payload)
+    Redis.current.publish('timeline:public:local', @payload) if status.local?
   end
 
   def deliver_to_media(status)
     Rails.logger.debug "Delivering status #{status.id} to media timeline"
 
-    Redis.current.publish('timeline:public:media', @payload) if !status.has_timelinemute_tag?
-    Redis.current.publish('timeline:public:local:media', @payload) if status.local? and !status.has_timelinemute_tag?
+    Redis.current.publish('timeline:public:media', @payload)
+    Redis.current.publish('timeline:public:local:media', @payload) if status.local?
   end
 
   def deliver_to_direct_timelines(status)

--- a/spec/models/status_spec.rb
+++ b/spec/models/status_spec.rb
@@ -212,30 +212,24 @@ RSpec.describe Status, type: :model do
   end
 
   describe '#has_mutetag' do
-    context 'has a #timelinemute hashtag' do
-      let(:account) { Fabricate(:account) }
-
-      subject = Fabricate(:status, account: account)
-
+    describe 'on a status with a #timelinemute tag' do
       before do
         subject.text = "blahblahblah #TimelineMute"
         subject.save!
       end
 
-      it 'is true if #timelinemute is among the tags' do
+      it 'returns true' do
         expect(subject.has_mutetag?).to be true
       end
     end
 
-    context 'does not have a #timelinemute hashtag' do
-      subject { Status.new }
-
+    describe 'on a status without a #timelinemute tag' do
       before do
         subject.text = "blahblahblah adfdsfsadf"
         subject.save!
       end
 
-      it 'is false if #timelinemute is not among the tags' do
+      it 'returns false' do
         expect(subject.has_mutetag?).to be false
       end
     end
@@ -542,23 +536,17 @@ RSpec.describe Status, type: :model do
       end
     end
 
-    context 'with a #timelinemute tag' do
-      let(:account) { Fabricate(:account) }
-
-      subject { Status.new }
+    context 'with a #timelinemute tag present' do
+      subject Status.as_public_timeline
 
       before do
-        subject.text = "blahblahblah #TimelineMute"
-        subject.save!
-      end
-
-      it 'detected the hashtag properly' do
-        expect(subject.tags.where(name: "timelinemute").exists?).to be true
+        @status = Fabricate(:status)
+        @status.text = "blahblahblah #TimelineMute"
+        @status.save!
       end
 
       it 'does not include statuses with #timelinemute tag' do
-        results = Status.as_public_timeline(:account, false)
-        expect(results).not_to include(subject)
+        expect(subject).not_to include(@status)
       end
     end
 

--- a/spec/models/status_spec.rb
+++ b/spec/models/status_spec.rb
@@ -512,6 +512,15 @@ RSpec.describe Status, type: :model do
       end
     end
 
+    it 'does not includes statuses with #timelinemute tag' do
+      normal_status = Fabricate(:status, visibility: :public, text: 'blahblah asdfasdf')
+      muted_status = Fabricate(:status, visibility: :public, text: 'blahblah #TimelineMute')
+
+      results = Status.as_public_timeline
+      expect(results).to include(normal_status)
+      expect(results).not_to include(muted_status)
+    end
+
     describe 'with an account passed in' do
       before do
         @account = Fabricate(:account)

--- a/spec/models/status_spec.rb
+++ b/spec/models/status_spec.rb
@@ -528,7 +528,7 @@ RSpec.describe Status, type: :model do
     describe 'with a #timelinemute tag' do
       subject { Status.new }
 
-      describe 'on a status with a #timelinemute tag'
+      describe 'on a status with a #timelinemute tag' do
         before do
           subject.text = "blahblahblah #TimelineMute"
           subject.save!

--- a/spec/models/status_spec.rb
+++ b/spec/models/status_spec.rb
@@ -212,15 +212,30 @@ RSpec.describe Status, type: :model do
   end
 
   describe '#has_mutetag' do
-    let(:normal_status) { Fabricate(:status, account: alice, visibility: :public, text: 'blahblah wibble') }
-    let(:muted_status) { Fabricate(:status, account: alice, visibility: :public, text: 'blahblah #TimelineMute') }
+    context 'has a #timelinemute hashtag' do
+      subject { Status.new }
 
-    it 'is false if #timelinemute is not among the tags' do
-      expect(normal_status.has_mutetag?).to be false
+      before do
+        subject.text = "blahblahblah #TimelineMute"
+        subject.save!
+      end
+
+      it 'is true if #timelinemute is among the tags' do
+        expect(subject.has_mutetag?).to be true
+      end
     end
 
-    it 'is true if #timelinemute is among the tags' do
-      expect(muted_status.has_mutetag?).to be true
+    context 'does not have a #timelinemute hashtag' do
+      subject { Status.new }
+
+      before do
+        subject.text = "blahblahblah adfdsfsadf"
+        subject.save!
+      end
+
+      it 'is false if #timelinemute is not among the tags' do
+        expect(subject.has_mutetag?).to be false
+      end
     end
   end
 
@@ -523,23 +538,23 @@ RSpec.describe Status, type: :model do
           expect(subject).not_to include(remote_status)
         end
       end
-    end
 
-    describe 'with a #timelinemute tag' do
-      subject { Status.new }
+      context 'with a #timelinemute tag' do
+        let(:account) { Fabricate(:account) }
 
-      describe 'on a status with a #timelinemute tag' do
+        subject { Status.new }
+
         before do
           subject.text = "blahblahblah #TimelineMute"
           subject.save!
         end
 
-        it 'did the tag thing correctly' do
+        it 'detected the hashtag properly' do
           expect(subject.tags.where(name: "timelinemute").exists?).to be true
         end
 
         it 'does not include statuses with #timelinemute tag' do
-          results = Status.as_public_timeline
+          results = Status.as_public_timeline(:account, false)
           expect(results).not_to include(subject)
         end
       end

--- a/spec/models/status_spec.rb
+++ b/spec/models/status_spec.rb
@@ -211,6 +211,19 @@ RSpec.describe Status, type: :model do
     end
   end
 
+  describe '#has_mutetag' do
+    let(:normal_status) { Fabricate(:status, account: alice, visibility: :public, text: 'blahblah wibble') }
+    let(:muted_status) { Fabricate(:status, account: alice, visibility: :public, text: 'blahblah #TimelineMute') }
+
+    it 'is false if #timelinemute is not among the tags' do
+      expect(normal_status.has_mutetag).to be false
+    end
+
+    it 'is true if #timelinemute is among the tags' do
+      expect(muted_status.has_mutetag).to be true
+    end
+  end
+
   describe 'on create' do
     let(:local_account) { Fabricate(:account, username: 'local', domain: nil) }
     let(:remote_account) { Fabricate(:account, username: 'remote', domain: 'example.com') }

--- a/spec/models/status_spec.rb
+++ b/spec/models/status_spec.rb
@@ -215,7 +215,7 @@ RSpec.describe Status, type: :model do
     context 'has a #timelinemute hashtag' do
       let(:account) { Fabricate(:account) }
 
-      subject = Fabricate(:status, account: alice)
+      subject = Fabricate(:status, account: account)
 
       before do
         subject.text = "blahblahblah #TimelineMute"

--- a/spec/models/status_spec.rb
+++ b/spec/models/status_spec.rb
@@ -537,7 +537,7 @@ RSpec.describe Status, type: :model do
     end
 
     context 'with a #timelinemute tag present' do
-      subject Status.as_public_timeline
+      subject { Status.as_public_timeline }
 
       before do
         @status = Fabricate(:status)

--- a/spec/models/status_spec.rb
+++ b/spec/models/status_spec.rb
@@ -214,7 +214,9 @@ RSpec.describe Status, type: :model do
   describe '#has_mutetag' do
     describe 'on a status with a #timelinemute tag' do
       before do
+        tag = Fabricate(:tag, name: 'timelinemute')
         subject.text = "blahblahblah #TimelineMute"
+        subject.tags = [tag]
         subject.save!
       end
 
@@ -225,6 +227,7 @@ RSpec.describe Status, type: :model do
 
     describe 'on a status without a #timelinemute tag' do
       before do
+        Fabricate(:tag, name: 'timelinemute')
         subject.text = "blahblahblah adfdsfsadf"
         subject.save!
       end

--- a/spec/models/status_spec.rb
+++ b/spec/models/status_spec.rb
@@ -216,11 +216,11 @@ RSpec.describe Status, type: :model do
     let(:muted_status) { Fabricate(:status, account: alice, visibility: :public, text: 'blahblah #TimelineMute') }
 
     it 'is false if #timelinemute is not among the tags' do
-      expect(normal_status.has_mutetag).to be false
+      expect(normal_status.has_mutetag?).to be false
     end
 
     it 'is true if #timelinemute is among the tags' do
-      expect(muted_status.has_mutetag).to be true
+      expect(muted_status.has_mutetag?).to be true
     end
   end
 
@@ -525,13 +525,26 @@ RSpec.describe Status, type: :model do
       end
     end
 
-    it 'does not includes statuses with #timelinemute tag' do
-      normal_status = Fabricate(:status, visibility: :public, text: 'blahblah asdfasdf')
-      muted_status = Fabricate(:status, visibility: :public, text: 'blahblah #TimelineMute')
+    context 'with a #timelinemute tag' do
+      before do
+        @normal_status = Fabricate(:status, visibility: :public)
+        @muted_status = Fabricate(:status, visibility: :public, text: 'blahblah #TimelineMute')
+      end
 
-      results = Status.as_public_timeline
-      expect(results).to include(normal_status)
-      expect(results).not_to include(muted_status)
+      it 'did the tag thing correctly' do
+        expect(@muted_status.tags.where(name: "timelinemute").exists?).to be true
+        expect(@normal_status.tags.where(name: "timelinemute").exists?).to be false
+      end
+
+      it 'does not include statuses with #timelinemute tag' do
+        results = Status.as_public_timeline
+        expect(results).not_to include(muted_status)
+      end
+
+      it 'does include statuses without #timelinemute tag' do
+        results = Status.as_public_timeline
+        expect(results).to include(normal_status)
+      end
     end
 
     describe 'with an account passed in' do

--- a/spec/models/status_spec.rb
+++ b/spec/models/status_spec.rb
@@ -525,25 +525,23 @@ RSpec.describe Status, type: :model do
       end
     end
 
-    context 'with a #timelinemute tag' do
-      before do
-        @normal_status = Fabricate(:status, visibility: :public)
-        @muted_status = Fabricate(:status, visibility: :public, text: 'blahblah #TimelineMute')
-      end
+    describe 'with a #timelinemute tag' do
+      subject { Status.new }
 
-      it 'did the tag thing correctly' do
-        expect(@muted_status.tags.where(name: "timelinemute").exists?).to be true
-        expect(@normal_status.tags.where(name: "timelinemute").exists?).to be false
-      end
+      describe 'on a status with a #timelinemute tag'
+        before do
+          subject.text = "blahblahblah #TimelineMute"
+          subject.save!
+        end
 
-      it 'does not include statuses with #timelinemute tag' do
-        results = Status.as_public_timeline
-        expect(results).not_to include(muted_status)
-      end
+        it 'did the tag thing correctly' do
+          expect(subject.tags.where(name: "timelinemute").exists?).to be true
+        end
 
-      it 'does include statuses without #timelinemute tag' do
-        results = Status.as_public_timeline
-        expect(results).to include(normal_status)
+        it 'does not include statuses with #timelinemute tag' do
+          results = Status.as_public_timeline
+          expect(results).not_to include(subject)
+        end
       end
     end
 

--- a/spec/models/status_spec.rb
+++ b/spec/models/status_spec.rb
@@ -213,7 +213,9 @@ RSpec.describe Status, type: :model do
 
   describe '#has_mutetag' do
     context 'has a #timelinemute hashtag' do
-      subject { Status.new }
+      let(:account) { Fabricate(:account) }
+
+      subject = Fabricate(:status, account: alice)
 
       before do
         subject.text = "blahblahblah #TimelineMute"
@@ -538,25 +540,25 @@ RSpec.describe Status, type: :model do
           expect(subject).not_to include(remote_status)
         end
       end
+    end
 
-      context 'with a #timelinemute tag' do
-        let(:account) { Fabricate(:account) }
+    context 'with a #timelinemute tag' do
+      let(:account) { Fabricate(:account) }
 
-        subject { Status.new }
+      subject { Status.new }
 
-        before do
-          subject.text = "blahblahblah #TimelineMute"
-          subject.save!
-        end
+      before do
+        subject.text = "blahblahblah #TimelineMute"
+        subject.save!
+      end
 
-        it 'detected the hashtag properly' do
-          expect(subject.tags.where(name: "timelinemute").exists?).to be true
-        end
+      it 'detected the hashtag properly' do
+        expect(subject.tags.where(name: "timelinemute").exists?).to be true
+      end
 
-        it 'does not include statuses with #timelinemute tag' do
-          results = Status.as_public_timeline(:account, false)
-          expect(results).not_to include(subject)
-        end
+      it 'does not include statuses with #timelinemute tag' do
+        results = Status.as_public_timeline(:account, false)
+        expect(results).not_to include(subject)
       end
     end
 

--- a/spec/models/status_spec.rb
+++ b/spec/models/status_spec.rb
@@ -539,13 +539,12 @@ RSpec.describe Status, type: :model do
       end
     end
 
-    context 'with a #timelinemute tag present' do
+    context 'with a mutetag present' do
       subject { Status.as_public_timeline }
 
       before do
-        @status = Fabricate(:status)
-        @status.text = "blahblahblah #TimelineMute"
-        @status.save!
+        @tag = Fabricate(:tag, name: 'timelinemute')
+        @status = Fabricate(:status, text: "blahblahblah #TimelineMute", tags: [@tag])
       end
 
       it 'does not include statuses with #timelinemute tag' do


### PR DESCRIPTION
This feature keeps the local/federated timelines from getting crowded by bots like @nowplaying@vulpine.club, while still letting them appear in hashtag searches.