### PR TITLE
Don't post statuses to public TLs if they have a #timelinemute tag

### DIFF
--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -259,6 +259,7 @@ class Status < ApplicationRecord
         query = query
                 .joins("LEFT JOIN statuses_tags ON statuses_tags.status_id = statuses.id AND statuses_tags.tag_id IN (#{mutetag.ids.join(',')})")
                 .where("statuses_tags.status_id is NULL")
+      end
 
       apply_timeline_filters(query, account, local_only)
     end

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -257,7 +257,7 @@ class Status < ApplicationRecord
 
       if mutetag.exists?
         query = query
-                .joins("LEFT JOIN statuses_tags ON statuses_tags.status_id = statuses.id AND statuses_tags.tag_id = #{mutetag[0].id}")
+                .joins("LEFT JOIN statuses_tags ON statuses_tags.status_id = statuses.id AND statuses_tags.tag_id IN (#{mutetag.ids.join(',')})")
                 .where("statuses_tags.status_id is NULL")
 
       apply_timeline_filters(query, account, local_only)

--- a/app/services/fan_out_on_write_service.rb
+++ b/app/services/fan_out_on_write_service.rb
@@ -24,7 +24,7 @@ class FanOutOnWriteService < BaseService
 
     return if status.reply? && status.in_reply_to_account_id != status.account_id
 
-    deliver_to_public(status) unless status.has_mutetag?
+    deliver_to_public(status)
     deliver_to_media(status) if status.media_attachments.any?
   end
 

--- a/app/services/fan_out_on_write_service.rb
+++ b/app/services/fan_out_on_write_service.rb
@@ -24,7 +24,7 @@ class FanOutOnWriteService < BaseService
 
     return if status.reply? && status.in_reply_to_account_id != status.account_id
 
-    deliver_to_public(status)
+    deliver_to_public(status) unless status.has_mutetag?
     deliver_to_media(status) if status.media_attachments.any?
   end
 

--- a/spec/models/status_spec.rb
+++ b/spec/models/status_spec.rb
@@ -211,6 +211,33 @@ RSpec.describe Status, type: :model do
     end
   end
 
+  describe '#has_mutetag' do
+    describe 'on a status with a #timelinemute tag' do
+      before do
+        tag = Fabricate(:tag, name: 'timelinemute')
+        subject.text = "blahblahblah #TimelineMute"
+        subject.tags = [tag]
+        subject.save!
+      end
+
+      it 'returns true' do
+        expect(subject.has_mutetag?).to be true
+      end
+    end
+
+    describe 'on a status without a #timelinemute tag' do
+      before do
+        Fabricate(:tag, name: 'timelinemute')
+        subject.text = "blahblahblah adfdsfsadf"
+        subject.save!
+      end
+
+      it 'returns false' do
+        expect(subject.has_mutetag?).to be false
+      end
+    end
+  end
+
   describe 'on create' do
     let(:local_account) { Fabricate(:account, username: 'local', domain: nil) }
     let(:remote_account) { Fabricate(:account, username: 'remote', domain: 'example.com') }
@@ -509,6 +536,19 @@ RSpec.describe Status, type: :model do
           expect(subject).to include(local_status)
           expect(subject).not_to include(remote_status)
         end
+      end
+    end
+
+    context 'with a mutetag present' do
+      subject { Status.as_public_timeline }
+
+      before do
+        @tag = Fabricate(:tag, name: 'timelinemute')
+        @status = Fabricate(:status, text: "blahblahblah #TimelineMute", tags: [@tag])
+      end
+
+      it 'does not include statuses with #timelinemute tag' do
+        expect(subject).not_to include(@status)
       end
     end
 


### PR DESCRIPTION
This feature keeps the local/federated timelines from getting crowded by bots like @nowplaying@vulpine.club, while still letting them appear in hashtag searches.